### PR TITLE
타입스크립트 설치/세팅 & 필수 문법 정리(변수, 배열, 객체, 함수, Union Type, Type alias)

### DIFF
--- a/typescript/index.js
+++ b/typescript/index.js
@@ -1,0 +1,17 @@
+// 간단한 변수 타입 지정
+var 이름 = "kim"; // 이 변수엔 string만 들어올 수 있음
+// array 타입 지정
+var 이름2 = ["kim", "park"];
+// object 타입 지정
+var 이름3 = { name: "kim" };
+var 이름4 = {}; // name 속성이 들어올수도 안들어올수도 (옵션)
+var john2 = { name: "kim" };
+// union Type - 다양한 타입 지정
+var 이름5 = "kim";
+var 이름6 = 123;
+// 함수에 타입 지정 가능
+function 함수(x) {
+    // 변수 x 타입: number, return 타입: number
+    return x * 2;
+}
+var john = [123, true];

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -1,0 +1,33 @@
+// 간단한 변수 타입 지정
+let 이름: string = "kim"; // 이 변수엔 string만 들어올 수 있음
+
+// array 타입 지정
+let 이름2: string[] = ["kim", "park"];
+
+// object 타입 지정
+let 이름3: { name: string } = { name: "kim" };
+let 이름4: { name?: string } = {}; // name 속성이 들어올수도 안들어올수도 (옵션)
+
+type Member = {
+  [key: string]: string; // 글자로 된 모든 object 속성의 타입은 string
+};
+
+let john2: Member = { name: "kim" };
+
+// union Type - 다양한 타입 지정
+let 이름5: string | number = "kim";
+
+// type alias - 타입을 변수에 담아 쓸 수 있음
+// 대문자 작명을 많이 함
+type Name = string | number;
+let 이름6: Name = 123;
+
+// 함수에 타입 지정 가능
+function 함수(x: number): number {
+  // 변수 x 타입: number, return 타입: number
+  return x * 2;
+}
+
+// array에 쓸 수 있는 tuple 타입
+type Member2 = [number, boolean];
+let john: Member2 = [123, true];

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
# TypeScript
- 자바스크립트에 타입을 부여한 언어(자바스크립트의 확장된 언어)
- 브라우저는 JS 파일만 읽을 수 있기 때문에 한번의 컴파일 과정이 필요하다 -> `tsc -w

## 타입스크립트 설치 방법
**1. HTML/CSS/JS 프로젝트에서 TS 사용하기**
```
npm install -g typescript
sudo npm install -g typescript
```

**2. React 프로젝트에서 TS 사용하기**
  - 이미 있는 React 프로젝트에 설치
  ```
  npm install --save typescript @types/node @types/react @types/react-dom @types/jest
  ```
  
  - 새로운 React 프로젝트에 설치
  ```
  npx create-react-app my-app --template typescript
  ```

## 타입스크립트 컴파일시 세부 설정 (tsconfig.json)
- 리액트 혹은 뷰 사용 중이라면 이미 있을 수도 있음
```
{
    "compilerOptions": {
        "target": "es5",
        "module": "commonjs",
    }
}
```
- target: 타입스크립트 파일을 어떤 버전의 JS로 바꿔 줄지 정하는 부분
- module: 자바스크립트 파일간 import 문법을 구현할 때 어떤 문법을 쓸지 정하는 곳
- noImplicitAny: any라는 타입이 의도치않게 발생할 경우 에러를 띄워주는 설정
- strictNullChecks: 모든 타입은 null, undefined 값을 가질 수 없고, 가지려면 union type 을 이용해서 직접 명시

## 타입스크립트를 써야하는 이유
- 에러를 사전에 방지할 수 있음
- 코드 자동완성과 가이드

## 타입스크립트 간단 필수 문법
### 간단한 변수 타입 지정
  ```
  let 이름: string = "kim";
  ```
  - 이 변수엔 string만 들어올 수 있음

### 배열(array) 타입 지정
  ```
  let 이름2: string[] = ["kim", "park"];
  ```

### 객체(object) 타입 지정
  ```
  let 이름3: { name: string } = { name: "kim" };
  ```
  ```
  let 이름4: { name?: string } = {};
  ```
  -  name 속성이 들어올수도 안들어올수도 (옵션)
  ```
  type Member = {
    [key: string]: string 
  }
  
  let john2: Member = {name: 'kim'}
  ```
  - 글자로 된 모든 object 속성의 타입은 string
 
### 함수(function) 타입 지정
```
function 함수(x: number) :number{ 
  return x * 2;
}
```
- 변수 x 타입: number, return 타입: number
- 파라미터와 return 값이 어떤 타입일지 지정 가능
- return 타입으로 void를 설정 가능 -> return이 없는지 체크할 수 있는 타입
- 지금의 변수 타입이 확실하지 않으면 연산할 수 없음 -> 타입 체크하는 narrowing 또는 assertion 문법 사용

### Union Type 
- 다양한 타입을 지정하는 방법
  ```
  let 이름5: string | number = "kim";
  ```
  ```
  type NameType = 'kim' | 'park;
  let 이름 :NameType = 'kim';
  ```
  - 나만의 타입을 만들어서 사용하는 것도 가능
  - 변수에 kim 또는 park만 들어올 수 있다

### Type alias
- 타입을 변수에 담아 쓰는 방법
```
type Name = string | number;
let 이름6: Name = 123;
```
- 대문자 작명을 주로 한다

### tuple 타입
- array 자료 안에 순서를 포함하여 어떤 자료가 들어올지 정확하게 지정
  ```
  type Member2 = [number, boolean]
  let john:Member2 = [123, true]
  ```