### PR TITLE
함수의 타입 지정

### DIFF
--- a/typescript/ts04.js
+++ b/typescript/ts04.js
@@ -1,0 +1,37 @@
+// 함수의 타입 지정
+function 함수41(x) {
+    return x * 2;
+}
+// 함수에서 void 타입 활용 가능
+function 함수42(x) {
+    1 + 1;
+}
+// 파라미터가 옵션일 경우
+function 함수43(x) {
+    1 + 1;
+}
+함수43();
+// 문제1)
+function question41(x) {
+    if (x) {
+        console.log("\uC548\uB155\uD558\uC138\uC694 ".concat(x));
+    }
+    else {
+        console.log("이름이 없습니다");
+    }
+}
+// 문제2)
+function question42(x) {
+    return x.toString().length;
+}
+// 문제3)
+function question43(money, house, charm) {
+    var score = 0;
+    score += money;
+    if (house)
+        score += 500;
+    if (charm === "상")
+        score += 100;
+    if (score >= 600)
+        return "결혼가능";
+}

--- a/typescript/ts04.ts
+++ b/typescript/ts04.ts
@@ -1,0 +1,41 @@
+// 함수의 타입 지정
+function 함수41(x: number): number {
+  return x * 2;
+}
+
+// 함수에서 void 타입 활용 가능
+function 함수42(x: number) {
+  1 + 1;
+}
+
+// 파라미터가 옵션일 경우
+function 함수43(x?: number) {
+  1 + 1;
+}
+
+함수43();
+
+// 문제1)
+function question41(x?: string) {
+  if (x) {
+    console.log(`안녕하세요 ${x}`);
+  } else {
+    console.log("이름이 없습니다");
+  }
+}
+
+// 문제2)
+function question42(x: number | string): number {
+  return x.toString().length;
+}
+
+// 문제3)
+function question43(money: number, house: boolean, charm: string) {
+  let score: number = 0;
+
+  score += money;
+  if (house) score += 500;
+  if (charm === "상") score += 100;
+
+  if (score >= 600) return "결혼가능";
+}


### PR DESCRIPTION
- 함수의 타입 지정
    
    ```jsx
    function 함수(x: number): number {
      return x * 2;
    }
    ```
    
    - 파라미터와 return 값의 타입 지정 가능
    - return값을 주고 싶지 않을 경우 void 타입 활용 가능
        
        ```jsx
        function 함수2(x: number){
          1 + 1
        }
        ```
        
        실수로 return 하는 에러를 방지할 수 있음
        
        (JS 함수에 return이 없는 경우 `undefined` 가 반환됨
        
    - JS와 다른 점 → 타입 지정된 파라미터는 필수
        
        
- 파라미터가 옵션일 경우
    
    ```jsx
    function 함수3(x?: number) {
      1 + 1;
    }
    ```
    
    - `변수? :타입` === `변수: 타입 | undefined`