### PR TITLE
변수에 타입 담아쓰기 (type alias & readonly)

### DIFF
--- a/typescript/index.html
+++ b/typescript/index.html
@@ -7,6 +7,6 @@
     <title></title>
   </head>
   <body>
-    <script src="ts05.js"></script>
+    <script src="ts06.js"></script>
   </body>
 </html>

--- a/typescript/ts06.js
+++ b/typescript/ts06.js
@@ -1,0 +1,11 @@
+// type alias
+var 동물 = "cat";
+var 사람 = { name: "kim", age: 20 };
+var 여친 = {
+    name: "엠버",
+};
+var 회원가입정보 = {
+    name: "kim",
+    children: false,
+    phone: 1234,
+};

--- a/typescript/ts06.ts
+++ b/typescript/ts06.ts
@@ -1,0 +1,52 @@
+// type alias
+
+type Animal = string | number | undefined;
+let 동물: Animal = "cat";
+
+type Person = { name: string; age: number };
+let 사람: Person = { name: "kim", age: 20 };
+
+// object 자료 수정 막기 (readonly)
+type Girlfreind = {
+  readonly name: string;
+};
+
+const 여친: Girlfreind = {
+  name: "엠버",
+};
+
+// type 변수의 union type
+type Name61 = string;
+type Age61 = number;
+type Person61 = Name61 | Age61;
+
+// object type 합치기
+type PositionX = { x: number };
+type PositionY = { y: number };
+
+type NewType = PositionX & PositionY; // {x: number, y: number}
+
+// 문제1)
+type QuestionType = {
+  color?: string;
+  size: number;
+  readonly position: number[];
+};
+
+// 문제2)
+type QuestionType2 = {
+  name: string;
+  phone: number;
+  email?: string;
+};
+
+// 문제3)
+type QuestionType3 = QuestionType2 & {
+  children: boolean;
+};
+
+let 회원가입정보: QuestionType3 = {
+  name: "kim",
+  children: false,
+  phone: 1234,
+};


### PR DESCRIPTION
## type alias

```jsx
type Animal = string | number | undefined

let 동물:Animal = 'cat'
```

- type 변수는 대문자로 작명하는 것이 좋음
- 같은 이름의 type 변수 재정의 불가능
- type 변수의 union type
    
    ```jsx
    type Name61 = string
    type Age61 = number
    type Person61 = Name61 | Age61
    ```
    
- & 연산자를 이용한 object 타입 합치기 (& 연산자로 object 타입 extend 하기)
    
    ```jsx
    type PositionX = {x: number}
    type PositionY = {y: number}
    
    type NewType = PositionX & PositionY // {x: number, y: number}
    ```
    

## readonly

- 타입스크리트를 쓰면 object의 자료 수정 막는 것이 가능
    
    ```jsx
    type Girlfreind = {
      readonly name: string
    }
    
    const 여친:Girlfreind ={
      name: '엠버'
    }
    ```
    
    - object 속성 안에도 ? 키워드 사용 가능