### PR TITLE
리터럴타입

### DIFF
--- a/typescript/index.html
+++ b/typescript/index.html
@@ -7,6 +7,6 @@
     <title></title>
   </head>
   <body>
-    <script src="ts06.js"></script>
+    <script src="ts07.js"></script>
   </body>
 </html>

--- a/typescript/ts07.js
+++ b/typescript/ts07.js
@@ -1,0 +1,24 @@
+// Literal types
+var 이름71; // 이름이라는 변수에는 무조건 kim이라는 문자만 들어올 수 있음
+var me;
+function 함수71(a) {
+    return 1;
+}
+// 문제1)
+function Question71(x) {
+    return ["가위"];
+}
+// 리터럴 타입의 문제점
+var 자료 = {
+    name: "kim",
+};
+function 함수72(a) { }
+// 함수72(자료.name) 에러
+// 이유: 'kim'이라는 자료만 들어올 수 있다는 뜻이 아니라 'kim'이라는 '타입'만 들어올 수 있음
+// 해결법
+var 자료2 = {
+    name: "kim",
+};
+// obejct value 값을 그대로 타입으로 지정해 줌
+function 함수73(a) { }
+함수73(자료2.name);

--- a/typescript/ts07.ts
+++ b/typescript/ts07.ts
@@ -1,0 +1,33 @@
+// Literal types
+let 이름71: "kim"; // 이름이라는 변수에는 무조건 kim이라는 문자만 들어올 수 있음
+let me: "단발" | "여자";
+
+function 함수71(a: "hello"): 1 | 0 {
+  return 1;
+}
+
+// 문제1)
+function Question71(x: "가위" | "바위" | "보"): ("가위" | "바위" | "보")[] {
+  return ["가위"];
+}
+
+// 리터럴 타입의 문제점
+const 자료 = {
+  name: "kim",
+};
+
+function 함수72(a: "kim") {}
+
+// 함수72(자료.name) 에러
+// 이유: 'kim'이라는 자료만 들어올 수 있다는 뜻이 아니라 'kim'이라는 '타입'만 들어올 수 있음
+
+// 해결법
+
+const 자료2 = {
+  name: "kim",
+} as const;
+// obejct value 값을 그대로 타입으로 지정해 줌
+
+function 함수73(a: "kim") {}
+
+함수73(자료2.name);


### PR DESCRIPTION
- 더 엄격한 타입 지정
    
    
  ![image](https://user-images.githubusercontent.com/96907832/232533372-eec74269-92bc-45fd-a66a-00ac458758cb.png)

    
- 함수에서의 리터럴타입
  ![image](https://user-images.githubusercontent.com/96907832/232533561-6aa42ee7-c6c1-41f6-83ad-081cc85aabae.png)

    
    ```jsx
    function 함수71(a: 'hello') : 1|0{
      return 1
    }
    ```
    
- Literal type의 문제점
    
    ```jsx
    const 자료 = {
      name: 'kim'
    }
    
    function 함수72(a: 'kim'){
    
    }
    
    // 함수72(자료.name) 에러
    ```
    
    - 'kim'이라는 자료만 들어올 수 있다는 뜻이 아니라 'kim'이라는 '타입'만 들어올 수 있음
    - 해결법
        - as const 키워드 사용
            - object를 잠구는 효과
            - obejct value 값을 그대로 타입으로 지정해 주는 효과 (타입을 ‘kim’으로 바꿔 줌)
            - object 안에 있는 모든 속성을 `readonly` 로 바꿔 주는 효과 (변경하면 에러나도록)
                
                ```jsx
                const 자료2 = {
                  name: 'kim'
                } as const
                
                function 함수73(a: 'kim'){
                
                }
                
                함수73(자료2.name)
                ```