### PR TITLE
튜플 타입으로 타입 지정

### DIFF
--- a/typescript/ts15.js
+++ b/typescript/ts15.js
@@ -1,0 +1,54 @@
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+// 튜플 타입
+var dog = ["dog", true];
+// 함수에서 쓰는 튜플
+function 함수151() {
+    var x = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        x[_i] = arguments[_i];
+    }
+    console.log(x);
+}
+함수151(111, "222");
+// 스프레드 문법 쓸 때의 타입 지정
+var arr151 = [1, 2, 3];
+var arr152 = __spreadArray([4, 5], arr151, true);
+// 문제1)
+var myFood = ["브라우니", 1000, true];
+// 문제2)
+var arr153 = [
+    "동서녹차",
+    4000,
+    true,
+    false,
+    true,
+    true,
+    false,
+    true,
+];
+// 문제3)
+function question153() {
+    var rest = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        rest[_i] = arguments[_i];
+    }
+}
+question153("a", true, 6, 3, "1", 4);
+// 문제4)
+function question154() {
+    var x = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        x[_i] = arguments[_i];
+    }
+    var result = [[], []];
+    x.map(function (v) { return (typeof v === "string" ? result[0].push(v) : result[1].push(v)); });
+    return result;
+}

--- a/typescript/ts15.ts
+++ b/typescript/ts15.ts
@@ -1,0 +1,42 @@
+// 튜플 타입
+let dog: [string, boolean] = ["dog", true];
+
+// 함수에서 쓰는 튜플
+function 함수151(...x: [number, string]) {
+  console.log(x);
+}
+
+함수151(111, "222");
+
+// 스프레드 문법 쓸 때의 타입 지정
+let arr151 = [1, 2, 3];
+let arr152: [number, number, ...number[]] = [4, 5, ...arr151];
+
+// 문제1)
+let myFood: [string, number, boolean] = ["브라우니", 1000, true];
+
+// 문제2)
+let arr153: [string, number, ...boolean[]] = [
+  "동서녹차",
+  4000,
+  true,
+  false,
+  true,
+  true,
+  false,
+  true,
+];
+
+// 문제3)
+function question153(...rest: [string, boolean, ...(number | string)[]]) {}
+
+question153("a", true, 6, 3, "1", 4);
+
+// 문제4)
+function question154(...x: [number | string]) {
+  let result: [string[], number[]] = [[], []];
+
+  x.map((v) => (typeof v === "string" ? result[0].push(v) : result[1].push(v)));
+
+  return result;
+}


### PR DESCRIPTION
- 위치까지 고려한 타입지정 가능
    
    ```jsx
    let dog: [string, boolean] = ["dog", true];
    ```
    
- 튜플 안에 옵션 표시 가능
    - 옵션 표시는 가장 뒤에 써야함
        
        ```jsx
        let dog: [string, boolean?] = ["dog"];
        ```
        
- 함수에서 쓰는 튜플
    
    ```jsx
    function 함수151(...x: [number, string]){
      console.log(x)
    }
    
    함수151(111, '222')
    ```
    
- 스프레드 문법 쓸 때의 타입 지정
    
    ```jsx
    let arr151 = [1,2,3]
    let arr152: [number, number, ...number[]] = [4,5, ...arr151]
    ```